### PR TITLE
Log errors to Rails logger

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -368,6 +368,11 @@ module OneLogin
 
         if collect_errors
           validations.each { |validation| send(validation) }
+          unless @errors.empty?
+            if defined? Rails
+              Rails.logger.warn("SAML ERRORS: #{@errors}")
+            end
+          end
           @errors.empty?
         else
           validations.all? { |validation| send(validation) }


### PR DESCRIPTION
In order to diagnose failed SAML requests, let's log them to the Rails logger.

We'll need to run `bundle update ruby-saml` in p3p after merging this.