### PR TITLE
Improve error messages; Add notes about CNO vs. ININ

### DIFF
--- a/lib/xml_security.rb
+++ b/lib/xml_security.rb
@@ -187,6 +187,7 @@ module XMLSecurity
     include OneLogin::RubySaml::ErrorHandling
 
     attr_accessor :signed_element_id
+    attr_reader :errors
 
     def initialize(response, errors = [])
       super(response)
@@ -223,18 +224,13 @@ module XMLSecurity
 
         # check cert matches registered idp cert
         if fingerprint != idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
-          @errors << "Fingerprint mismatch"
           return append_error("Fingerprint mismatch", soft)
         end
       else
         if options[:cert]
           base64_cert = Base64.encode64(options[:cert].to_pem)
         else
-          if soft
-            return false
-          else
-            return append_error("Certificate element missing in response (ds:X509Certificate) and not cert provided at settings", soft)
-          end
+          return append_error("Certificate element missing in response (ds:X509Certificate) and not cert provided at settings", soft)
         end
       end
       validate_signature(base64_cert, soft)

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -396,7 +396,7 @@ class RubySamlTest < Minitest::Test
           collect_errors = true
           response_invalid_subjectconfirmation_recipient.is_valid?(collect_errors)
           assert_includes response_invalid_subjectconfirmation_recipient.errors, "invalid is not a valid audience for this Response - Valid audiences: http://stuff.com/endpoints/metadata.php"
-          assert_includes response_invalid_subjectconfirmation_recipient.errors, "Invalid Signature on SAML Response"
+          assert_includes response_invalid_subjectconfirmation_recipient.errors, "Invalid Signature on SAML Response: Fingerprint mismatch"
         end
       end
     end
@@ -760,7 +760,7 @@ class RubySamlTest < Minitest::Test
         settings.idp_cert_fingerprint = signature_fingerprint_1
         response.settings = settings
         assert !response.send(:validate_signature)
-        assert_includes response.errors, "Invalid Signature on SAML Response"
+        assert_includes response.errors, "Invalid Signature on SAML Response: Fingerprint mismatch"
       end
 
       it "return false when no X509Certificate and not cert provided at settings" do
@@ -768,7 +768,7 @@ class RubySamlTest < Minitest::Test
         settings.idp_cert = nil
         response_valid_signed_without_x509certificate.settings = settings
         assert !response_valid_signed_without_x509certificate.send(:validate_signature)
-        assert_includes response_valid_signed_without_x509certificate.errors, "Invalid Signature on SAML Response"
+        assert_includes response_valid_signed_without_x509certificate.errors, "Invalid Signature on SAML Response: Certificate element missing in response (ds:X509Certificate) and not cert provided at settings"
       end
 
       it "return false when no X509Certificate and the cert provided at settings mismatches" do
@@ -776,7 +776,7 @@ class RubySamlTest < Minitest::Test
         settings.idp_cert = signature_1
         response_valid_signed_without_x509certificate.settings = settings
         assert !response_valid_signed_without_x509certificate.send(:validate_signature)
-        assert_includes response_valid_signed_without_x509certificate.errors, "Invalid Signature on SAML Response"
+        assert_includes response_valid_signed_without_x509certificate.errors, "Invalid Signature on SAML Response: Key validation error"
       end
 
       it "return true when no X509Certificate and the cert provided at settings matches" do
@@ -795,7 +795,7 @@ class RubySamlTest < Minitest::Test
         settings.idp_cert_fingerprint = "afe71c28ef740bc87425be13a2263d37971da1f9"
         response_wrapped.settings = settings
         assert !response_wrapped.send(:validate_signature)
-        assert_includes response_wrapped.errors, "Invalid Signature on SAML Response"
+        assert_includes response_wrapped.errors, "Signature missing on SAML Response"
        end
     end
 


### PR DESCRIPTION
What this is:

1. Improved error messages-  Turns out the generic error message wasn't including the error messages from child objects.
2. Some notes about the CNO vs. ININ code paths
3. An update to one of the ININ specific selectors, based on manual perusal of the XML in the ININ requests

Other thoughts:

1.  We should add this to CI.  I keep almost forgetting to run the tests.
2.  After merging this, we'll have to `bundle update ruby-saml` in the saml PR.